### PR TITLE
Local zarrs with blusc usage

### DIFF
--- a/bindings-js/demo/src/Demo.jsx
+++ b/bindings-js/demo/src/Demo.jsx
@@ -78,12 +78,12 @@ const DEMOS = {
             point_radius_unit_mode: "Pixels",
             point_shape_mode: "Circle",
             point_radius: 5.0,
-            store_name: "gaussian_quantiles_store",
+            store_name: "gaussian_quantiles_store_compressed",
             bounds: null,
 
-            x_key: "/n_1000000/x_coords",
-            y_key: "/n_1000000/y_coords",
-            color_key: "/n_1000000/class_labels",
+            x_key: "/n_100000/x_coords",
+            y_key: "/n_100000/y_coords",
+            color_key: "/n_100000/class_labels",
           }
         },
         {

--- a/pluot_core/Cargo.toml
+++ b/pluot_core/Cargo.toml
@@ -54,13 +54,16 @@ serde = { version = "1.0.x", features = ["derive"] }
 uuid = { version = "1", features = ["v4", "js"] }
 # Note: zarrs is also specified in dev-dependencies,
 # since its "filesystem" feature is used for unit tests.
-zarrs = { version = "0.23.0", default-features = false, features = [
+#zarrs = { version = "0.23.0", default-features = false, features = [
+zarrs = { path = "../../zarrs/zarrs", default-features = false, features = [
     "ndarray",
     "crc32c",
     "gzip",
     "sharding",
     "transpose",
     "async",
+    "zstd",
+    "blosc", # Using the "zstd" and "blosc" features adds ~1MB to the .wasm size in --release mode.
     # "filesystem", # was working under zarrs_filesystem v0.3.8, stopped working in zarrs_filesystem v0.3.9
 ] }
 async-trait = "0.1.74"
@@ -150,7 +153,8 @@ image = "0.25.9" # For read/write to image formats like PNG in unit tests.
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 # Note zarrs is also used for core dependencies (but without its "filesystem" feature). "filesystem" is needed for unit tests.
-zarrs = { version = "0.23.0", default-features = false, features = [
+#zarrs = { version = "0.23.0", default-features = false, features = [
+zarrs = { path = "../../zarrs/zarrs", default-features = false, features = [
     "ndarray",
     "crc32c",
     "gzip",


### PR DESCRIPTION
Working with forked zarrs that uses blusc for blosc https://github.com/keller-mark/zarrs/tree/keller-mark/try-blusc-v2

Fixes keller-mark/pluot-private#4 

Closes keller-mark/pluot-private#5 