### PR TITLE
Define Default::default for more layerParams structs

### DIFF
--- a/crates/pluot/tests/test_line_layer.rs
+++ b/crates/pluot/tests/test_line_layer.rs
@@ -35,7 +35,7 @@ fn cross_lines_data() -> LineLayerParams {
         source_position_y: Arc::new(vec![0.0, 0.0, 0.0, 0.5, 0.5, 0.75, 0.50, 1.00]),
         target_position_x: Arc::new(vec![1.0, 0.0, 1.0, 0.5, 0.5, 0.70, 1.00, 1.00]),
         target_position_y: Arc::new(vec![0.0, 0.5, 0.5, 1.0, 1.0, 1.00, 1.00, 1.00]),
-        labels_vec: vec![0, 1, 2, 3, 4, 5, 6, 7],
+        labels_vec: Arc::new(vec![0, 1, 2, 3, 4, 5, 6, 7]),
     }
 }
 
@@ -53,7 +53,7 @@ fn cross_lines_pixels() -> LineLayerParams {
         source_position_y: Arc::new(vec![  0.0,  0.0,   0.0, 50.0,  50.0,  75.0,  50.0, 100.0]),
         target_position_x: Arc::new(vec![100.0,  0.0, 100.0, 50.0,  50.0,  70.0, 100.0, 100.0]),
         target_position_y: Arc::new(vec![  0.0, 50.0,  50.0,100.0, 100.0, 100.0, 100.0, 100.0]),
-        labels_vec: vec![0, 1, 2, 3, 4, 5, 6, 7],
+        labels_vec: Arc::new(vec![0, 1, 2, 3, 4, 5, 6, 7]),
     }
 }
 

--- a/crates/pluot/tests/test_multi_layer.rs
+++ b/crates/pluot/tests/test_multi_layer.rs
@@ -55,7 +55,7 @@ fn cross_lines() -> LineLayerParams {
         source_position_y: Arc::new(vec![0.0, 0.0]),
         target_position_x: Arc::new(vec![1.0, 0.0]),
         target_position_y: Arc::new(vec![1.0, 1.0]),
-        labels_vec: vec![0, 1],
+        labels_vec: Arc::new(vec![0, 1]),
     }
 }
 

--- a/crates/pluot_core/src/layers/axis_band_layer.rs
+++ b/crates/pluot_core/src/layers/axis_band_layer.rs
@@ -18,12 +18,23 @@ const DEFAULT_FONT_SIZE: f64 = 12.0;
 const DEFAULT_LINE_WIDTH: f32 = 1.0;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct AxisBandLayerParams {
     pub layer_id: String,
     pub position: AxisPosition,
     pub domain: Arc<Vec<String>>,
 
     // TODO: support a data_unit_mode param?
+}
+
+impl Default for AxisBandLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            position: AxisPosition::Bottom,
+            domain: Arc::new(vec![]),
+        }
+    }
 }
 
 pub struct AxisBandLayer {
@@ -192,7 +203,7 @@ impl AxisBandLayer {
             source_position_y: Arc::new(line_source_position_y),
             target_position_x: Arc::new(line_target_position_x),
             target_position_y: Arc::new(line_target_position_y),
-            labels_vec: line_labels_vec,
+            labels_vec: Arc::new(line_labels_vec),
         };
         sublayers.push(Box::new(LineLayer::new(
             self.view_params.clone(),

--- a/crates/pluot_core/src/layers/axis_linear_layer.rs
+++ b/crates/pluot_core/src/layers/axis_linear_layer.rs
@@ -30,11 +30,21 @@ pub enum AxisPosition {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct AxisLinearLayerParams {
     pub layer_id: String,
     pub position: AxisPosition,
 
     // TODO: support a data_unit_mode param.
+}
+
+impl Default for AxisLinearLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            position: AxisPosition::Bottom,
+        }
+    }
 }
 
 pub struct AxisLinearLayer {
@@ -232,7 +242,7 @@ impl AxisLinearLayer {
             source_position_y: Arc::new(line_source_position_y),
             target_position_x: Arc::new(line_target_position_x),
             target_position_y: Arc::new(line_target_position_y),
-            labels_vec: line_labels_vec, // TODO: make this optional in LineLayerParams
+            labels_vec: Arc::new(line_labels_vec), // TODO: make this optional in LineLayerParams
         };
         sublayers.push(Box::new(LineLayer::new(
             self.view_params.clone(),

--- a/crates/pluot_core/src/layers/bitmap_layer.rs
+++ b/crates/pluot_core/src/layers/bitmap_layer.rs
@@ -144,6 +144,7 @@ impl DimensionOrder {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct BitmapLayerParams {
     pub layer_id: String,
     // If None, assume margin: 0 in all directions.
@@ -193,7 +194,23 @@ pub struct BitmapLayerParams {
     pub data: NumericData,
 }
 
-// TODO: defaults for params?
+impl Default for BitmapLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            bounds: None,
+            data_unit_mode_x: UnitsMode::Data,
+            data_unit_mode_y: UnitsMode::Data,
+            pixel_offset: None,
+            model_matrix: None,
+            dimension_order: DimensionOrder::CYX,
+            shape: vec![],
+            channel_settings: vec![],
+            opacity: 1.0,
+            data: NumericData::Uint8(Arc::new(vec![])),
+        }
+    }
+}
 
 
 pub struct BitmapLayer {

--- a/crates/pluot_core/src/layers/line_layer.rs
+++ b/crates/pluot_core/src/layers/line_layer.rs
@@ -16,6 +16,7 @@ use crate::positioning::get_point_position;
 
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct LineLayerParams {
     pub layer_id: String,
     // If None, assume margin: 0 in all directions.
@@ -31,10 +32,27 @@ pub struct LineLayerParams {
     pub target_position_x: Arc<Vec<f32>>,
     pub target_position_y: Arc<Vec<f32>>,
     // TODO: improve naming here
-    pub labels_vec: Vec<i32>,
+    pub labels_vec: Arc<Vec<i32>>,
 }
 
-// TODO: defaults for params?
+impl Default for LineLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            bounds: None,
+            data_unit_mode_x: UnitsMode::Data,
+            data_unit_mode_y: UnitsMode::Data,
+            line_width: 1.0,
+            line_width_unit_mode: UnitsMode::Pixels,
+            model_matrix: None,
+            source_position_x: Arc::new(vec![]),
+            source_position_y: Arc::new(vec![]),
+            target_position_x: Arc::new(vec![]),
+            target_position_y: Arc::new(vec![]),
+            labels_vec: Arc::new(vec![]),
+        }
+    }
+}
 
 
 pub struct LineLayer {

--- a/crates/pluot_core/src/layers/point_3d_layer.rs
+++ b/crates/pluot_core/src/layers/point_3d_layer.rs
@@ -19,6 +19,7 @@ use crate::layers::point_layer::PointShapeMode;
 
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct Point3dLayerParams {
     pub layer_id: String,
     pub bounds: Option<MarginParams>,
@@ -29,6 +30,21 @@ pub struct Point3dLayerParams {
     pub position_y: Arc<Vec<f32>>,
     pub position_z: Arc<Vec<f32>>,
     pub labels_vec: Arc<Vec<i32>>,
+}
+
+impl Default for Point3dLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            bounds: None,
+            point_radius: 1.0,
+            point_shape_mode: PointShapeMode::Circle,
+            position_x: Arc::new(vec![]),
+            position_y: Arc::new(vec![]),
+            position_z: Arc::new(vec![]),
+            labels_vec: Arc::new(vec![]),
+        }
+    }
 }
 
 pub struct Point3dLayer {

--- a/crates/pluot_core/src/layers/rect_layer.rs
+++ b/crates/pluot_core/src/layers/rect_layer.rs
@@ -19,6 +19,7 @@ use crate::two::svg::{update_svg, SvgContext};
 use crate::wgpu;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct RectLayerParams {
     pub layer_id: String,
     // If None, assume margin: 0 in all directions.
@@ -45,6 +46,27 @@ pub struct RectLayerParams {
     pub position_x1: Arc<Vec<f32>>,
     pub position_y1: Arc<Vec<f32>>,
     pub labels_vec: Arc<Vec<i32>>,
+}
+
+impl Default for RectLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            bounds: None,
+            data_unit_mode_x: UnitsMode::Data,
+            data_unit_mode_y: UnitsMode::Data,
+            stroke_width: None,
+            stroke_width_unit_mode: UnitsMode::Pixels,
+            model_matrix: None,
+            fill_color_mode: ColorMode::Static,
+            fill_color: None,
+            position_x0: Arc::new(vec![]),
+            position_y0: Arc::new(vec![]),
+            position_x1: Arc::new(vec![]),
+            position_y1: Arc::new(vec![]),
+            labels_vec: Arc::new(vec![]),
+        }
+    }
 }
 
 // TODO: consider eliminating once we have a PolygonLayer?

--- a/crates/pluot_core/src/layers/text_layer.rs
+++ b/crates/pluot_core/src/layers/text_layer.rs
@@ -390,6 +390,7 @@ pub enum TextBaselineMode {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct TextLayerParams {
     pub layer_id: String,
     // If None, assume margin: 0 in all directions.
@@ -411,6 +412,29 @@ pub struct TextLayerParams {
     pub position_x: Arc<Vec<f32>>, // TODO: generalize to other numeric dtypes?
     pub position_y: Arc<Vec<f32>>,
     pub text_vec: Arc<Vec<String>>,
+}
+
+impl Default for TextLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            bounds: None,
+            data_unit_mode_x: UnitsMode::Data,
+            data_unit_mode_y: UnitsMode::Data,
+            text_size: 12.0,
+            text_size_unit_mode: UnitsMode::Pixels,
+            text_align_mode: TextAlignMode::Start,
+            text_baseline_mode: TextBaselineMode::Alphabetic,
+            text_rotation: None,
+            model_matrix: None,
+            font_family: None,
+            font_weight: FontWeight::Normal,
+            font_style: FontStyle::Normal,
+            position_x: Arc::new(vec![]),
+            position_y: Arc::new(vec![]),
+            text_vec: Arc::new(vec![]),
+        }
+    }
 }
 
 // TODO: defaults for params?

--- a/crates/pluot_core/src/params.rs
+++ b/crates/pluot_core/src/params.rs
@@ -88,6 +88,7 @@ pub enum PlotParams {
 
 /// The params that are passed to the [`crate::render::render`] function.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct RenderParams {
     /// The width of the plot, in pixels.
     pub width: u32,

--- a/crates/pluot_zarr/src/layers/ome_zarr_bitmap_layer.rs
+++ b/crates/pluot_zarr/src/layers/ome_zarr_bitmap_layer.rs
@@ -23,6 +23,7 @@ use pluot_core::layers::multiscale_utils::to_y_slice;
 
 /// Parameters for constructing an `OmeZarrBitmapLayer`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct OmeZarrBitmapLayerParams {
     /// Zarr store name. Falls back to view_params.store_name if None.
     pub store_name: Option<String>,
@@ -51,6 +52,7 @@ pub struct OmeZarrBitmapLayerParams {
 
     /// Model matrix encoding the physical voxel size and any affine transforms.
     /// The parent layer should convert per-resolution scale values into this matrix.
+    // TODO: make optional?
     pub model_matrix: [f32; 16],
 
     // Optional X and Y slice ranges for this tile. If None, the full range of the array is loaded.
@@ -64,6 +66,34 @@ pub struct OmeZarrBitmapLayerParams {
     pub bounds: Option<MarginParams>,
     pub opacity: f32,
     pub layer_id: String,
+}
+
+impl Default for OmeZarrBitmapLayerParams {
+    fn default() -> Self {
+        Self {
+            store_name: None,
+            array_path: "".to_string(),
+            array_metadata: None,
+            array_shape: vec![],
+            array_chunk_shape: vec![],
+            array_dimension_order: OmeDimensionOrder::new(vec![OmeDim::Y, OmeDim::X]),
+            target_z: None,
+            target_t: None,
+            // Column-major identity matrix.
+            model_matrix: [
+                1.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 0.0, 0.0,
+                0.0, 0.0, 1.0, 0.0,
+                0.0, 0.0, 0.0, 1.0,
+            ],
+            slice_x: None,
+            slice_y: None,
+            channel_settings: vec![],
+            bounds: None,
+            opacity: 1.0,
+            layer_id: "".to_string(),
+        }
+    }
 }
 
 /// A sublayer that loads a single OME-Zarr tile in `prepare()` and delegates

--- a/crates/pluot_zarr/src/layers/ome_zarr_multiscale_layer.rs
+++ b/crates/pluot_zarr/src/layers/ome_zarr_multiscale_layer.rs
@@ -32,6 +32,7 @@ use crate::layers::ome_zarr_utils::{
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct OmeZarrMultiscaleLayerParams {
     pub layer_id: String,
     pub bounds: Option<MarginParams>,
@@ -48,6 +49,22 @@ pub struct OmeZarrMultiscaleLayerParams {
     /// Channel settings specifying which channels to render and how.
     pub channel_settings: Vec<OmeZarrChannelSetting>,
     pub opacity: f32,
+}
+
+impl Default for OmeZarrMultiscaleLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            bounds: None,
+            store_name: None,
+            group_path: None,
+            multiscale_index: None,
+            target_z: None,
+            target_t: None,
+            channel_settings: vec![],
+            opacity: 1.0,
+        }
+    }
 }
 
 thread_local! {

--- a/crates/pluot_zarr/src/layers/zarr_bar_plot_layer.rs
+++ b/crates/pluot_zarr/src/layers/zarr_bar_plot_layer.rs
@@ -18,6 +18,7 @@ use pluot_core::viewport::DataCoord;
 use pluot_core::viewport::ScreenCoord;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct ZarrBarPlotLayerParams {
     pub layer_id: String,
     pub bounds: Option<MarginParams>,
@@ -32,6 +33,21 @@ pub struct ZarrBarPlotLayerParams {
     pub fill_color_mode: ColorMode,
 
     // TODO: see TODOs in bar_plot_layer.rs
+}
+
+impl Default for ZarrBarPlotLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            bounds: None,
+            orientation: BarOrientation::Vertical,
+            store_name: None,
+            identifier_key: "".to_string(),
+            quantity_key: "".to_string(),
+            fill_color: None,
+            fill_color_mode: ColorMode::Static,
+        }
+    }
 }
 
 pub struct ZarrBarPlotLayer {

--- a/crates/pluot_zarr/src/layers/zarr_histogram_layer.rs
+++ b/crates/pluot_zarr/src/layers/zarr_histogram_layer.rs
@@ -15,6 +15,7 @@ use pluot_core::compute::reduce::{reduce_extent, reduce_histogram_with_known_ext
 use pluot_core::plot_layers::bar_plot_layer::{BarOrientation, BarPlotLayer, BarPlotLayerParams};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct ZarrHistogramLayerParams {
     pub layer_id: String,
     pub bounds: Option<MarginParams>,
@@ -33,6 +34,21 @@ pub struct ZarrHistogramLayerParams {
     pub cache_data: bool,
 
     pub fill_color: Option<(u8, u8, u8)>,
+}
+
+impl Default for ZarrHistogramLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            bounds: None,
+            orientation: BarOrientation::Vertical,
+            store_name: None,
+            data_key: "".to_string(),
+            num_bins: 50,
+            cache_data: true,
+            fill_color: None,
+        }
+    }
 }
 
 pub struct ZarrHistogramLayer {

--- a/crates/pluot_zarr/src/layers/zarr_point_3d_layer.rs
+++ b/crates/pluot_zarr/src/layers/zarr_point_3d_layer.rs
@@ -18,6 +18,7 @@ use pluot_core::render_types::GpuContext;
 use pluot_core::LayerPickingResult;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct ZarrPoint3dLayerParams {
     pub layer_id: String,
     pub bounds: Option<MarginParams>,
@@ -30,6 +31,22 @@ pub struct ZarrPoint3dLayerParams {
     pub y_key: String,
     pub z_key: String,
     pub color_key: Option<String>,
+}
+
+impl Default for ZarrPoint3dLayerParams {
+    fn default() -> Self {
+        Self {
+            layer_id: "".to_string(),
+            bounds: None,
+            point_radius: 1.0,
+            point_shape_mode: PointShapeMode::Circle,
+            store_name: None,
+            x_key: "".to_string(),
+            y_key: "".to_string(),
+            z_key: "".to_string(),
+            color_key: None,
+        }
+    }
 }
 
 pub struct ZarrPoint3dLayerData {


### PR DESCRIPTION
Towards #127 
TODO:
- [ ] Add basic validation in layer constructors for inconsistent params (e.g., vec lengths, missing layer_id strings, etc)
- [ ] Make more things optional when it makes sense to do so