### PR TITLE
Define extent trait and bindings

### DIFF
--- a/bindings-js/core/src/core.ts
+++ b/bindings-js/core/src/core.ts
@@ -3,7 +3,7 @@ import { lru, type LruStore } from "./lru-store.js";
 import type { AsyncReadable } from "zarrita";
 import { FontStore } from "./fonts.js";
 
-export const { render_wasm, render_to_script_wasm, pick_wasm, brush_wasm } = wasm;
+export const { render_wasm, render_to_script_wasm, pick_wasm, brush_wasm, extent_wasm } = wasm;
 
 // Global stores singleton.
 const stores: Record<string, LruStore<AsyncReadable>> = {};

--- a/bindings-js/core/src/index.ts
+++ b/bindings-js/core/src/index.ts
@@ -5,6 +5,7 @@ export {
   render_to_script_wasm,
   pick_wasm,
   brush_wasm,
+  extent_wasm,
   setStore,
   setStoreByName,
   getStore,

--- a/bindings-js/docs/src/components/PluotWrapper.jsx
+++ b/bindings-js/docs/src/components/PluotWrapper.jsx
@@ -330,7 +330,8 @@ export function PluotWrapper(props) {
           aspectRatioAlignmentMode={aspectRatioAlignmentMode}
           format={format}
           debugMargins={debugMargins}
-          cameraMatrix={enableCamera ? cameraMatrix : IDENTITY_CAMERA}
+          xLim={null}
+          yLim={null}
           setCameraMatrix={enableCamera ? setCameraMatrix : NOOP}
           enableClick={enableClick}
           enableTooltip={enableTooltip}

--- a/bindings-js/docs/src/content/docs/examples/histogram.mdx
+++ b/bindings-js/docs/src/content/docs/examples/histogram.mdx
@@ -40,10 +40,6 @@ The histogram values are computed via WebGPU compute shaders, and then passed to
     marginTop={10}
     marginRight={10}
     width={700}
-    cameraMatrix={[
-      0.15, 0.0, 0.0, 0.0,
-      0.0, 0.00001, 0.0, 0.0,
-      0.0, 0.0, 1.0, 0.0,
-      0.0, -1.0, 0.0, 1.0,
-    ]}
+    xLim={null}
+    yLim={null}
 />

--- a/bindings-js/react/src/Pluot.tsx
+++ b/bindings-js/react/src/Pluot.tsx
@@ -103,8 +103,8 @@ export function Pluot(props: PluotProps) {
     backgroundColor = undefined,
     cameraMatrix: controlledCameraMatrix = null,
     setCameraMatrix: setControlledCameraMatrix = null,
-    xLim = null,
-    yLim = null,
+    xLim: xLimProp = null,
+    yLim: yLimProp = null,
     enableClick = false,
     enableTooltip = false,
     onClick: onClickProp = null,
@@ -318,7 +318,7 @@ export function Pluot(props: PluotProps) {
       plot_type: plotType,
       stores,
       plot_params: plotParams,
-      timeout: currentTimeout.current,
+      timeout: null, // Note: no timeout
       wait_for_store_gets: false,
       cache_enabled: true,
       svg_compression_enabled: true,
@@ -338,6 +338,7 @@ export function Pluot(props: PluotProps) {
     if (!result || result.layer_results.length === 0) {
       return { x: null, y: null };
     }
+    console.log(result)
     let xMin = Infinity, xMax = -Infinity, yMin = Infinity, yMax = -Infinity;
     for (const { x, y } of result.layer_results) {
       xMin = Math.min(xMin, x[0]);
@@ -353,48 +354,68 @@ export function Pluot(props: PluotProps) {
   // since this effect is the one calling `setCameraMatrix` and must not re-fire
   // because of its own update.
   const applyLim = useEffectEvent(async () => {
+    // TODO: make this more like a useMemo (but it is async, which complicates things).
+
+    console.log(controlledCameraMatrix);
     // Mutually exclusive with a user-controlled camera matrix (see the `xLim`/
     // `yLim` prop docs), and a no-op when neither limit is specified.
-    if (controlledCameraMatrix !== null || (xLim == null && yLim == null)) {
-      return;
-    }
-
-    let x = xLim;
-    let y = yLim;
-
-    // Only the omitted dimension needs the full data extent (to "fit" it);
-    // when both are given, they fully determine the bounds on their own.
-    if (x == null || y == null) {
-      const fullExtent = unionExtent(await runExtent());
-      console.log(fullExtent);
-      if (x == null) x = fullExtent.x;
-      if (y == null) y = fullExtent.y;
-    }
-
-    if (x == null && y == null) {
+    if (controlledCameraMatrix !== null) {
       return;
     }
 
     const bounds: Bounds = {};
-    if (x != null) {
-      bounds.xMin = x[0];
-      bounds.xMax = x[1];
-    }
-    if (y != null) {
-      bounds.yMin = y[0];
-      bounds.yMax = y[1];
+
+    // TODO: generalize to 3D
+    // TODO: validate the contents of xLimProp/yLimProp (arrays with two numeric elements).
+    if (xLimProp !== null && yLimProp !== null) {
+      // Both xLim and yLim are specified explicitly via props,
+      // so we can use getCameraMatrixFromBounds without the need to call runExtent.
+      bounds.xMin = xLimProp[0];
+      bounds.xMax = xLimProp[1];
+      bounds.yMin = yLimProp[0];
+      bounds.yMax = yLimProp[1];
+    } else {
+      const fullExtent = unionExtent(await runExtent());
+      if (xLimProp === null) {
+        if(fullExtent.x) {
+          bounds.xMin = fullExtent.x[0];
+          bounds.xMax = fullExtent.x[1];
+        } else {
+          console.log("Warning: fullExtent.x was not computed.");
+        }
+      }
+      if (yLimProp === null) {
+        if(fullExtent.y) {
+          bounds.yMin = fullExtent.y[0];
+          bounds.yMax = fullExtent.y[1];
+        } else {
+          console.log("Warning: fullExtent.y was not computed.");
+        }
+      }
     }
 
-    setCameraMatrix(getCameraMatrixFromBounds(bounds, cameraMatrix, {
+    console.log(bounds);
+
+    const computedCameraMatrix = getCameraMatrixFromBounds(bounds, cameraMatrix, {
       width, height, aspectRatioMode, aspectRatioAlignmentMode,
       margins: { marginTop, marginRight, marginBottom, marginLeft },
-    }));
+    });
+    console.log(computedCameraMatrix);
+
+    setCameraMatrix(computedCameraMatrix);
+    // TODO: rather than workarounds to force a re-render,
+    // solve this issue by preventing the first render until the camera matrix
+    // has been fully specified (i.e., the useMemo comment above).
+    incBacklogIteration();
   });
 
   useEffect(() => {
     applyLim();
   }, [
-    isWasmReady, xLim, yLim, plotId, plotType, plotParams, stores,
+    isWasmReady, xLimProp, yLimProp,
+    plotId, // Note: for now, plotId must be modified to invalidate the cached extent.
+    // TODO: add a dedicated "extent invalidation key" prop?
+    // plotType, plotParams, stores, // Note: these are not `extent` dependencies.
     width, height, aspectRatioMode, aspectRatioAlignmentMode,
     marginTop, marginRight, marginBottom, marginLeft,
   ]);

--- a/bindings-js/react/src/Pluot.tsx
+++ b/bindings-js/react/src/Pluot.tsx
@@ -3,18 +3,19 @@ import lzs from "lz-string";
 import { throttle } from "lodash-es";
 import {
   initialize, getIsWasmReady,
-  render_wasm, pick_wasm, brush_wasm,
+  render_wasm, pick_wasm, brush_wasm, extent_wasm,
   normalizeStores, getStore,
   checkWebGpuFeatureDetection,
   onMouseMove2d, onWheel2d,
   onMouseMove3d, onWheel3d,
-  type CameraMatrix,
+  getCameraMatrixFromBounds,
+  type CameraMatrix, type Bounds,
 } from '@pluot/core';
 import { Tooltip } from "./Tooltip.js";
 import { BrushOverlay } from "./BrushOverlay.js";
 import { useBrush } from "./use-brush.js";
 import type {
-  BrushingResult, BrushState, HoverInfo, PickingResult, PluotProps, RawBrushingResult, RawPickingResult,
+  BrushingResult, BrushState, ExtentResult, HoverInfo, PickingResult, PluotProps, RawBrushingResult, RawPickingResult,
   RenderParams, TooltipContent,
 } from "./types.js";
 
@@ -102,6 +103,8 @@ export function Pluot(props: PluotProps) {
     backgroundColor = undefined,
     cameraMatrix: controlledCameraMatrix = null,
     setCameraMatrix: setControlledCameraMatrix = null,
+    xLim = null,
+    yLim = null,
     enableClick = false,
     enableTooltip = false,
     onClick: onClickProp = null,
@@ -289,6 +292,112 @@ export function Pluot(props: PluotProps) {
   useLayoutEffect(() => {
     initialize().then(() => setIsWasmReady(getIsWasmReady()));
   }, []);
+
+  // Runs the extent query against the wasm module, analogous to `runBrush` above.
+  const runExtent = useEffectEvent(async (): Promise<ExtentResult | undefined> => {
+    if (!isWasmReady) {
+      return undefined;
+    }
+
+    const renderParams: RenderParams = {
+      schema_version: schemaVersion,
+      width,
+      height,
+      format: format,
+      margin_bottom: marginBottom,
+      margin_left: marginLeft,
+      margin_top: marginTop,
+      margin_right: marginRight,
+      device_pixel_ratio: window.devicePixelRatio,
+      aspect_ratio_mode: aspectRatioMode,
+      aspect_ratio_alignment_mode: aspectRatioAlignmentMode,
+      view_mode: viewMode,
+      pickable: false,
+      camera_view: cameraMatrix,
+      plot_id: plotId,
+      plot_type: plotType,
+      stores,
+      plot_params: plotParams,
+      timeout: currentTimeout.current,
+      wait_for_store_gets: false,
+      cache_enabled: true,
+      svg_compression_enabled: true,
+      svg_include_document: false,
+    };
+
+    // Unlike `pick_wasm`/`brush_wasm`, `ExtentResult` has no `HashMap` fields,
+    // so `serde_wasm_bindgen` produces plain objects/arrays directly and no
+    // normalization step is needed.
+    return await extent_wasm(renderParams) as ExtentResult;
+  });
+
+  // The union (bounding box) of every layer's reported extent, in each axis
+  // independently. `null` for an axis when no layer in the plot reports an
+  // extent for it (e.g. none of them implement `ExtentableLayer` yet).
+  const unionExtent = (result: ExtentResult | undefined): { x: [number, number] | null, y: [number, number] | null } => {
+    if (!result || result.layer_results.length === 0) {
+      return { x: null, y: null };
+    }
+    let xMin = Infinity, xMax = -Infinity, yMin = Infinity, yMax = -Infinity;
+    for (const { x, y } of result.layer_results) {
+      xMin = Math.min(xMin, x[0]);
+      xMax = Math.max(xMax, x[1]);
+      yMin = Math.min(yMin, y[0]);
+      yMax = Math.max(yMax, y[1]);
+    }
+    return { x: [xMin, xMax], y: [yMin, yMax] };
+  };
+
+  // Applies `xLim`/`yLim` to the camera matrix, reading the latest `cameraMatrix`/
+  // `setCameraMatrix` (via useEffectEvent) rather than reacting to their changes,
+  // since this effect is the one calling `setCameraMatrix` and must not re-fire
+  // because of its own update.
+  const applyLim = useEffectEvent(async () => {
+    // Mutually exclusive with a user-controlled camera matrix (see the `xLim`/
+    // `yLim` prop docs), and a no-op when neither limit is specified.
+    if (controlledCameraMatrix !== null || (xLim == null && yLim == null)) {
+      return;
+    }
+
+    let x = xLim;
+    let y = yLim;
+
+    // Only the omitted dimension needs the full data extent (to "fit" it);
+    // when both are given, they fully determine the bounds on their own.
+    if (x == null || y == null) {
+      const fullExtent = unionExtent(await runExtent());
+      console.log(fullExtent);
+      if (x == null) x = fullExtent.x;
+      if (y == null) y = fullExtent.y;
+    }
+
+    if (x == null && y == null) {
+      return;
+    }
+
+    const bounds: Bounds = {};
+    if (x != null) {
+      bounds.xMin = x[0];
+      bounds.xMax = x[1];
+    }
+    if (y != null) {
+      bounds.yMin = y[0];
+      bounds.yMax = y[1];
+    }
+
+    setCameraMatrix(getCameraMatrixFromBounds(bounds, cameraMatrix, {
+      width, height, aspectRatioMode, aspectRatioAlignmentMode,
+      margins: { marginTop, marginRight, marginBottom, marginLeft },
+    }));
+  });
+
+  useEffect(() => {
+    applyLim();
+  }, [
+    isWasmReady, xLim, yLim, plotId, plotType, plotParams, stores,
+    width, height, aspectRatioMode, aspectRatioAlignmentMode,
+    marginTop, marginRight, marginBottom, marginLeft,
+  ]);
 
   const wheelHandler = useEffectEvent((event: WheelEvent) => {
     const onWheel = viewMode === "3d" ? onWheel3d : onWheel2d;

--- a/bindings-js/react/src/types.ts
+++ b/bindings-js/react/src/types.ts
@@ -150,6 +150,25 @@ export type RawPickingResult = Omit<PickingResult, "layer_results"> & {
   layer_results: RawLayerPickingResult[];
 };
 
+// === Extent ===
+
+/**
+ * Mirrors the Rust `LayerExtentResult` struct. `z` is only present for layers
+ * plotted in a 3D coordinate system; `serde_wasm_bindgen` serializes a Rust
+ * `None` as `undefined` (not `null`), so it is absent rather than null for 2D layers.
+ */
+export type LayerExtentResult = {
+  layer_id: string;
+  x: [number, number];
+  y: [number, number];
+  z: [number, number] | undefined;
+};
+
+/** Mirrors the Rust `ExtentResult` struct, as returned by `extent_wasm`. */
+export type ExtentResult = {
+  layer_results: LayerExtentResult[];
+};
+
 // === Tooltip ===
 
 /**
@@ -322,6 +341,14 @@ export type PluotProps = {
   cameraMatrix?: CameraMatrix | null;
   /** Provide to take control of the camera matrix. */
   setCameraMatrix?: ((cameraMatrix: CameraMatrix) => void) | null;
+
+  // Mutually exclusive from specifying a camera matrix,
+  // the user can specify xLim and/or yLim props in 2D.
+  // Then, we can use extent_wasm to fill in the camera matrix for the unspecified dimension(s).
+  // Note: when the camera matrix is fully specified, or both xLim AND yLim are defined,
+  // we never need to call extent_wasm.
+  xLim?: [number, number] | null;
+  yLim?: [number, number] | null;
 
   /** Whether clicking should run a picking query and call `onClick`. */
   enableClick?: boolean;

--- a/crates/pluot_core/src/bindings.rs
+++ b/crates/pluot_core/src/bindings.rs
@@ -8,6 +8,7 @@ pub use crate::render::{render, stores_from_params};
 pub use crate::render_script::render_to_script;
 pub use crate::picking::{pick, PickingResult};
 pub use crate::brushing::{brush, BrushParams, BrushingResult};
+pub use crate::extent::{extent, ExtentResult};
 pub use crate::viewport::ScreenCoord;
 pub use crate::zarr_types::ZarrPeekResult;
 
@@ -15,7 +16,7 @@ pub use crate::zarr_types::ZarrPeekResult;
 // == WASM Bindings ===
 #[cfg(target_arch = "wasm32")]
 pub mod wasm {
-    use super::{render, render_to_script, stores_from_params, pick, brush, RenderParams, ScreenCoord, BrushParams, ZarrPeekResult, CodeFormat};
+    use super::{render, render_to_script, stores_from_params, pick, brush, extent, RenderParams, ScreenCoord, BrushParams, ZarrPeekResult, CodeFormat};
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
@@ -289,6 +290,17 @@ export function zarr_get_range_from_end_status(store_name, key, suffix_length) {
 
         serde_wasm_bindgen::to_value(&result).expect("Failed to serialize BrushingResult")
     }
+
+    #[wasm_bindgen]
+    pub async fn extent_wasm(params: JsValue) -> JsValue {
+        let params: RenderParams =
+            serde_wasm_bindgen::from_value(params).expect("Invalid parameters");
+
+        let stores = stores_from_params(&params);
+        let result = extent(params, stores).await;
+
+        serde_wasm_bindgen::to_value(&result).expect("Failed to serialize ExtentResult")
+    }
 }
 
 // === Python Bindings ===
@@ -303,7 +315,7 @@ pub mod python {
     use pyo3_log::{Caching, Logger};
     use pythonize::depythonize;
 
-    use super::{render, render_to_script, stores_from_params, pick, brush, RenderParams, ScreenCoord, BrushParams, ZarrPeekResult, CodeFormat};
+    use super::{render, render_to_script, stores_from_params, pick, brush, extent, RenderParams, ScreenCoord, BrushParams, ZarrPeekResult, CodeFormat};
 
     #[pyfunction]
     pub fn log_info(s: &str) {
@@ -510,6 +522,27 @@ pub mod python {
 
     #[pyfunction]
     #[pyo3(signature = (**kwds))]
+    pub fn extent_py(py: Python, kwds: Option<Py<PyAny>>) -> PyResult<Bound<PyAny>> {
+        let params: RenderParams = if let Some(dict) = kwds {
+            depythonize::<RenderParams>(&dict.into_bound(py)).unwrap()
+        } else {
+            RenderParams::default()
+        };
+
+        let stores = stores_from_params(&params);
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let result = extent(params, stores).await;
+            Python::attach(|py| {
+                pythonize::pythonize(py, &result)
+                    .map(|v| v.unbind())
+                    .map_err(|e| PyErr::from(e))
+            })
+        })
+    }
+
+    #[pyfunction]
+    #[pyo3(signature = (**kwds))]
     pub fn render_py(py: Python, kwds: Option<Py<PyAny>>) -> PyResult<Bound<PyAny>> {
         // Use the py parameter directly instead of Python::with_gil
         let params: RenderParams = if let Some(dict) = kwds {
@@ -563,6 +596,7 @@ pub mod python {
         m.add_function(wrap_pyfunction!(render_py, m)?)?;
         m.add_function(wrap_pyfunction!(pick_py, m)?)?;
         m.add_function(wrap_pyfunction!(brush_py, m)?)?;
+        m.add_function(wrap_pyfunction!(extent_py, m)?)?;
         m.add_function(wrap_pyfunction!(render_to_script_py, m)?)?;
         Ok(())
     }

--- a/crates/pluot_core/src/composite_layers/axis_band_layer.rs
+++ b/crates/pluot_core/src/composite_layers/axis_band_layer.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use std::sync::Arc;
-use crate::render_traits::{BrushableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, PickableLayer, PreparedLayer, ViewParams, PreparedAndDraw, MarginParams, SizeMode, UnitsMode, FontWeight, FontStyle};
+use crate::render_traits::{BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, PickableLayer, PreparedLayer, ViewParams, PreparedAndDraw, MarginParams, SizeMode, UnitsMode, FontWeight, FontStyle};
 use crate::composite_layer::{base_draw_composite_layer, base_draw_composite_layer_svg, base_prepare_composite_layer};
 use crate::two::svg::SvgContext;
 use crate::layers::text_layer::{TextLayer, TextLayerParams, TextAlignMode, TextBaselineMode};
@@ -279,6 +279,8 @@ impl DrawToSvg for AxisBandLayer {
 }
 
 impl BrushableLayer for AxisBandLayer {}
+
+impl ExtentableLayer for AxisBandLayer {}
 
 impl PickableLayer for AxisBandLayer {}
 

--- a/crates/pluot_core/src/composite_layers/axis_linear_layer.rs
+++ b/crates/pluot_core/src/composite_layers/axis_linear_layer.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use std::sync::Arc;
-use crate::render_traits::{BrushableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, PickableLayer, PreparedLayer, ViewParams, PreparedAndDraw, MarginParams, SizeMode, UnitsMode, FontWeight, FontStyle};
+use crate::render_traits::{BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, PickableLayer, PreparedLayer, ViewParams, PreparedAndDraw, MarginParams, SizeMode, UnitsMode, FontWeight, FontStyle};
 use crate::viewport::get_bounds;
 use crate::composite_layer::{base_draw_composite_layer, base_draw_composite_layer_svg, base_prepare_composite_layer};
 use crate::two::svg::SvgContext;
@@ -391,5 +391,7 @@ inventory::submit! {
 }
 
 impl BrushableLayer for AxisLinearLayer {}
+
+impl ExtentableLayer for AxisLinearLayer {}
 
 impl PickableLayer for AxisLinearLayer {}

--- a/crates/pluot_core/src/composite_layers/bar_plot_layer.rs
+++ b/crates/pluot_core/src/composite_layers/bar_plot_layer.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use crate::render_traits::{
-    BrushableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, UnitsMode, ViewParams
+    BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, UnitsMode, ViewParams
 };
 use std::collections::HashMap;
 use crate::picking::LayerPickingResult;
@@ -289,6 +289,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for BarPlotLayer {}
+
+impl ExtentableLayer for BarPlotLayer {}
 
 impl PickableLayer for BarPlotLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/composite_layers/curve_layer.rs
+++ b/crates/pluot_core/src/composite_layers/curve_layer.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::picking::LayerPickingResult;
-use crate::render_traits::{BrushableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, EmphasisCriteria, OpacityMode, PickableLayer, PreparedLayer, SizeMode, ViewParams, UnitsMode, MarginParams};
+use crate::render_traits::{BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, EmphasisCriteria, OpacityMode, PickableLayer, PreparedLayer, SizeMode, ViewParams, UnitsMode, MarginParams};
 use crate::render_types::{CpuContext, CpuRenderPass, PrepareResult};
 use crate::render_types::GpuContext;
 use crate::two::svg::SvgContext;
@@ -245,6 +245,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for CurveLayer {}
+
+impl ExtentableLayer for CurveLayer {}
 
 impl PickableLayer for CurveLayer {
     // Delegate to the sub-layers, which own the actual curve geometry. The

--- a/crates/pluot_core/src/composite_layers/histogram_layer.rs
+++ b/crates/pluot_core/src/composite_layers/histogram_layer.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use crate::render_traits::{
-    BrushableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, UnitsMode, ViewParams
+    BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, UnitsMode, ViewParams
 };
 use crate::render_types::{CpuContext, CpuRenderPass, PrepareResult};
 use crate::render_types::GpuContext;
@@ -180,5 +180,7 @@ inventory::submit! {
 }
 
 impl BrushableLayer for HistogramLayer {}
+
+impl ExtentableLayer for HistogramLayer {}
 
 impl PickableLayer for HistogramLayer {}

--- a/crates/pluot_core/src/composite_layers/legend_colormap_quantitative_layer.rs
+++ b/crates/pluot_core/src/composite_layers/legend_colormap_quantitative_layer.rs
@@ -17,7 +17,7 @@ use crate::layers::bitmap_layer::{BitmapLayer, BitmapLayerParams, ChannelSetting
 use crate::layers::text_layer::{TextAlignMode, TextBaselineMode, TextLayer, TextLayerParams};
 use crate::numeric_data::NumericData;
 use crate::render_traits::{
-    AspectRatioMode, BrushableLayer, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, QuantitativeColormap, UnitsMode, ViewParams,
+    AspectRatioMode, BrushableLayer, ExtentableLayer, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, QuantitativeColormap, UnitsMode, ViewParams,
 };
 use crate::render_types::GpuContext;
 use crate::render_types::{CpuContext, CpuRenderPass, PrepareResult};
@@ -347,5 +347,7 @@ inventory::submit! {
 }
 
 impl BrushableLayer for LegendColormapQuantitativeLayer {}
+
+impl ExtentableLayer for LegendColormapQuantitativeLayer {}
 
 impl PickableLayer for LegendColormapQuantitativeLayer {}

--- a/crates/pluot_core/src/composite_layers/legend_point_size_quantitative_layer.rs
+++ b/crates/pluot_core/src/composite_layers/legend_point_size_quantitative_layer.rs
@@ -12,7 +12,7 @@ use crate::layers::point_layer::{PointLayer, PointLayerParams, PointShapeMode};
 use crate::layers::text_layer::{TextAlignMode, TextBaselineMode, TextLayer, TextLayerParams};
 use crate::numeric_data::NumericData;
 use crate::render_traits::{
-    BrushableLayer, ColorMode, InstancedSizeParams, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, SizeMode, UnitsMode, ViewParams,
+    BrushableLayer, ExtentableLayer, ColorMode, InstancedSizeParams, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, SizeMode, UnitsMode, ViewParams,
 };
 use crate::render_types::GpuContext;
 use crate::render_types::{CpuContext, CpuRenderPass, PrepareResult};
@@ -294,5 +294,7 @@ inventory::submit! {
 }
 
 impl BrushableLayer for LegendPointSizeQuantitativeLayer {}
+
+impl ExtentableLayer for LegendPointSizeQuantitativeLayer {}
 
 impl PickableLayer for LegendPointSizeQuantitativeLayer {}

--- a/crates/pluot_core/src/composite_layers/polygon_layer.rs
+++ b/crates/pluot_core/src/composite_layers/polygon_layer.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::picking::LayerPickingResult;
 use crate::render_traits::{
     ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg,
-    BrushableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams,
+    BrushableLayer, ExtentableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams,
 };
 use crate::render_types::{CpuContext, CpuRenderPass, GpuContext, PrepareResult};
 use crate::numeric_data::NumericData;
@@ -257,6 +257,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for PolygonLayer {}
+
+impl ExtentableLayer for PolygonLayer {}
 
 impl PickableLayer for PolygonLayer {
     // Delegate to the sub-layers, which own the actual polygon geometry.

--- a/crates/pluot_core/src/extent.rs
+++ b/crates/pluot_core/src/extent.rs
@@ -1,0 +1,99 @@
+// The extent analog of brushing.rs / picking.rs.
+use serde::{Serialize, Deserialize};
+
+use crate::wgpu;
+use crate::render_types::GpuContext;
+use crate::params::{PlotParams, RenderParams, RenderBackend, ComputeBackend};
+use crate::render_traits::{MarginParams, ViewParams, get_layers};
+use crate::cache::get_or_init_gpu_context;
+use crate::zarr::StoreMap;
+
+/// Serializable representation of the data extent
+/// reported by a single plotted layer.
+#[derive(Serialize, Deserialize)]
+pub struct LayerExtentResult {
+    pub layer_id: String,
+    pub x_min: f32,
+    pub x_max: f32,
+    pub y_min: f32,
+    pub y_max: f32,
+    // Only present for layers plotted in a 3D coordinate system.
+    pub z_min: Option<f32>,
+    pub z_max: Option<f32>,
+}
+
+/// Serializable representation of the data extents
+/// reported by one or more plotted layers.
+#[derive(Serialize, Deserialize)]
+pub struct ExtentResult {
+    pub layer_results: Vec<LayerExtentResult>,
+}
+
+/// Determine the data extent (min/max bounds along x, y, and z) of each layer.
+pub async fn extent(params: RenderParams, stores: Option<StoreMap>) -> ExtentResult {
+    // TODO: the stuff up to layer.prepare is duplicated from render(). Refactor to avoid duplication.
+    let width = params.width;
+    let height = params.height;
+
+    let view_params = ViewParams {
+        view_id: params.plot_id.clone(),
+        width,
+        height,
+        margins: Some(MarginParams {
+            margin_top: Some(params.margin_top.unwrap_or(0.0)),
+            margin_right: Some(params.margin_right.unwrap_or(0.0)),
+            margin_bottom: Some(params.margin_bottom.unwrap_or(0.0)),
+            margin_left: Some(params.margin_left.unwrap_or(0.0)),
+        }),
+        device_pixel_ratio: params.device_pixel_ratio,
+        camera_view: params.camera_view,
+        timeout: params.timeout,
+        wait_for_store_gets: params.wait_for_store_gets,
+        cache_enabled: params.cache_enabled,
+        aspect_ratio_mode: params.aspect_ratio_mode,
+        aspect_ratio_alignment_mode: params.aspect_ratio_alignment_mode,
+        stores: params.stores.clone(),
+        // Thread the concrete store objects down so layer constructors read from
+        // them directly instead of the global store registry.
+        store_objects: stores,
+    };
+
+    #[allow(irrefutable_let_patterns)]
+    let PlotParams::LayeredPlot(plot_params) = &params.plot_params else {
+        panic!("Expected layered plot params");
+    };
+
+    let mut layers = get_layers(&plot_params.layers, &view_params);
+
+    let owned_gpu_context: Option<(wgpu::Device, wgpu::Queue)>;
+    if params.render_backend == Some(RenderBackend::Gpu) || params.compute_backend == Some(ComputeBackend::Gpu) {
+        // GPU explicitly requested: panic if GPU support is unavailable.
+        owned_gpu_context = Some(
+            get_or_init_gpu_context().await
+                .expect("No suitable GPU adapters found on the system!")
+        );
+    } else if params.render_backend.is_none() || params.compute_backend.is_none() {
+        // Backend not specified: try GPU, then fall back to CPU gracefully without panicking.
+        owned_gpu_context = get_or_init_gpu_context().await;
+    } else {
+        owned_gpu_context = None;
+    }
+
+    let gpu_context = owned_gpu_context.as_ref().map(|(device, queue)| GpuContext { device, queue });
+
+    // Collect references first to avoid Send issues with the iterator
+    let prepare_futures: Vec<_> = layers.iter_mut().map(|layer| layer.prepare(gpu_context.as_ref())).collect();
+
+    // The layer extent is derived from state populated during `prepare`, so
+    // layers must be prepared before querying it, even though nothing else
+    // about the returned extents depends on the prepare results themselves.
+    let _prepare_results = futures::future::join_all(prepare_futures).await;
+
+    let layer_results: Vec<LayerExtentResult> = layers.iter_mut()
+        .filter_map(|layer| layer.extent())
+        .collect();
+
+    return ExtentResult {
+        layer_results,
+    };
+}

--- a/crates/pluot_core/src/extent.rs
+++ b/crates/pluot_core/src/extent.rs
@@ -13,13 +13,10 @@ use crate::zarr::StoreMap;
 #[derive(Serialize, Deserialize)]
 pub struct LayerExtentResult {
     pub layer_id: String,
-    pub x_min: f32,
-    pub x_max: f32,
-    pub y_min: f32,
-    pub y_max: f32,
+    pub x: (f32, f32),
+    pub y: (f32, f32),
     // Only present for layers plotted in a 3D coordinate system.
-    pub z_min: Option<f32>,
-    pub z_max: Option<f32>,
+    pub z: Option<(f32, f32)>,
 }
 
 /// Serializable representation of the data extents

--- a/crates/pluot_core/src/layers/bitmap_layer.rs
+++ b/crates/pluot_core/src/layers/bitmap_layer.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::picking::LayerPickingResult;
-use crate::render_traits::{AspectRatioMode, AspectRatioAlignmentMode, BrushableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams};
+use crate::render_traits::{AspectRatioMode, AspectRatioAlignmentMode, BrushableLayer, ExtentableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams};
 use crate::render_types::{CpuContext, CpuRenderPass, PrepareResult, RenderResult};
 use crate::viewport::{DataCoord, ScreenCoord};
 use crate::render_types::GpuContext;
@@ -853,6 +853,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for BitmapLayer {}
+
+impl ExtentableLayer for BitmapLayer {}
 
 impl PickableLayer for BitmapLayer {
     /// Pick the image pixel under the given data coordinate.

--- a/crates/pluot_core/src/layers/bitmask_layer.rs
+++ b/crates/pluot_core/src/layers/bitmask_layer.rs
@@ -41,7 +41,7 @@ use crate::numeric_data::NumericData;
 use crate::picking::LayerPickingResult;
 use crate::render_traits::{
     AspectRatioAlignmentMode, AspectRatioMode, ColorMode, DrawToRasterCpu, DrawToRasterGpu,
-    BrushableLayer, DrawToSvg, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode,
+    BrushableLayer, ExtentableLayer, DrawToSvg, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode,
     ViewParams,
 };
 use crate::render_types::{CpuContext, CpuRenderPass, GpuContext, PrepareResult, RenderResult};
@@ -1862,6 +1862,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for BitmaskLayer {}
+
+impl ExtentableLayer for BitmaskLayer {}
 
 impl PickableLayer for BitmaskLayer {
     /// Pick the object id under the given data coordinate, for each channel.

--- a/crates/pluot_core/src/layers/filled_curve_layer.rs
+++ b/crates/pluot_core/src/layers/filled_curve_layer.rs
@@ -12,7 +12,7 @@ use crate::positioning::get_point_position;
 use crate::numeric_data::NumericData;
 use crate::render_traits::{
     ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg,
-    BrushableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, UnitsMode, ViewParams,
+    BrushableLayer, ExtentableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, UnitsMode, ViewParams,
 };
 use crate::render_types::{CpuContext, CpuRenderPass, GpuContext, PrepareResult, RenderResult};
 use crate::color_mode::{cpu_fill_color, quantitative_domain};
@@ -276,6 +276,8 @@ impl DrawToSvg for FilledCurveLayer {
 }
 
 impl BrushableLayer for FilledCurveLayer {}
+
+impl ExtentableLayer for FilledCurveLayer {}
 
 impl PickableLayer for FilledCurveLayer {
     fn pick(&self, _screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/layers/filled_polygon_layer.rs
+++ b/crates/pluot_core/src/layers/filled_polygon_layer.rs
@@ -15,7 +15,7 @@ use crate::curve_and_polygon_utils::{
 use crate::picking_geometry::{point_in_polygon, unapply_model_matrix};
 use crate::render_traits::{
     ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg,
-    BrushableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, UnitsMode, ViewParams,
+    BrushableLayer, ExtentableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, UnitsMode, ViewParams,
 };
 use crate::render_types::{CpuContext, CpuRenderPass, GpuContext, PrepareResult, RenderResult};
 use crate::viewport::{DataCoord, ScreenCoord};
@@ -279,6 +279,8 @@ impl DrawToSvg for FilledPolygonLayer {
 }
 
 impl BrushableLayer for FilledPolygonLayer {}
+
+impl ExtentableLayer for FilledPolygonLayer {}
 
 impl PickableLayer for FilledPolygonLayer {
     fn pick(&self, _screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/layers/line_layer.rs
+++ b/crates/pluot_core/src/layers/line_layer.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::{Arc};
 
 use crate::picking::LayerPickingResult;
-use crate::render_traits::{BrushableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, EmphasisCriteria, PickableLayer, PreparedLayer, ViewParams, AspectRatioMode, AspectRatioAlignmentMode, OpacityMode, SizeMode, UnitsMode, MarginParams};
+use crate::render_traits::{BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, EmphasisCriteria, PickableLayer, PreparedLayer, ViewParams, AspectRatioMode, AspectRatioAlignmentMode, OpacityMode, SizeMode, UnitsMode, MarginParams};
 use crate::render_types::{CpuContext, CpuRenderPass, PrepareResult, RenderResult};
 use crate::viewport::{DataCoord, ScreenCoord};
 use crate::picking_geometry::{dist_sq_to_segment, unapply_model_matrix};
@@ -887,6 +887,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for LineLayer {}
+
+impl ExtentableLayer for LineLayer {}
 
 impl PickableLayer for LineLayer {
     fn pick(&self, _screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/layers/point_3d_layer.rs
+++ b/crates/pluot_core/src/layers/point_3d_layer.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use std::collections::HashMap;
 use crate::picking::LayerPickingResult;
-use crate::render_traits::{BrushableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, ViewParams};
+use crate::render_traits::{BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, ViewParams};
 use crate::viewport::{DataCoord, ScreenCoord};
 use crate::shader_modules::{common, ShaderBuilder};
 use crate::numeric_data::NumericData;
@@ -412,6 +412,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for Point3dLayer {}
+
+impl ExtentableLayer for Point3dLayer {}
 
 impl PickableLayer for Point3dLayer {
     fn pick(&self, _screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/layers/point_layer.rs
+++ b/crates/pluot_core/src/layers/point_layer.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc};
 use std::collections::HashMap;
 use crate::picking::LayerPickingResult;
 use crate::picking_geometry::unapply_model_matrix;
-use crate::render_traits::{AspectRatioMode, AspectRatioAlignmentMode, BrushableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams};
+use crate::render_traits::{AspectRatioMode, AspectRatioAlignmentMode, BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams};
 use crate::viewport::{DataCoord, ScreenCoord};
 use crate::shader_modules::{common, ShaderBuilder};
 use crate::numeric_data::NumericData;
@@ -1082,6 +1082,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for PointLayer {}
+
+impl ExtentableLayer for PointLayer {}
 
 impl PickableLayer for PointLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/layers/rect_layer.rs
+++ b/crates/pluot_core/src/layers/rect_layer.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc};
 
 use crate::picking::LayerPickingResult;
 use crate::render_traits::{
-    AspectRatioAlignmentMode, AspectRatioMode, BrushableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams
+    AspectRatioAlignmentMode, AspectRatioMode, BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams
 };
 use crate::positioning::{get_point_position, get_point_size};
 use crate::numeric_data::NumericData;
@@ -1016,6 +1016,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for RectLayer {}
+
+impl ExtentableLayer for RectLayer {}
 
 impl PickableLayer for RectLayer {
     fn pick(&self, _screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/layers/stroked_curve_layer.rs
+++ b/crates/pluot_core/src/layers/stroked_curve_layer.rs
@@ -16,7 +16,7 @@ use crate::picking::LayerPickingResult;
 use crate::positioning::{get_point_position, get_point_size};
 use crate::render_traits::{
     AspectRatioAlignmentMode, AspectRatioMode, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg,
-    BrushableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams,
+    BrushableLayer, ExtentableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams,
 };
 use crate::render_types::{CpuContext, CpuRenderPass, GpuContext, PrepareResult};
 use crate::color_mode::{cpu_fill_color, prepare_stroke_color, quantitative_domain};
@@ -721,6 +721,8 @@ impl DrawToSvg for StrokedCurveLayer {
 }
 
 impl BrushableLayer for StrokedCurveLayer {}
+
+impl ExtentableLayer for StrokedCurveLayer {}
 
 impl PickableLayer for StrokedCurveLayer {
     fn pick(&self, _screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/layers/stroked_polygon_layer.rs
+++ b/crates/pluot_core/src/layers/stroked_polygon_layer.rs
@@ -21,7 +21,7 @@ use crate::curve_and_polygon_utils::{
 use crate::picking_geometry::{dist_sq_to_segment, unapply_model_matrix};
 use crate::render_traits::{
     AspectRatioAlignmentMode, AspectRatioMode, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg,
-    BrushableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams,
+    BrushableLayer, ExtentableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, SizeMode, UnitsMode, ViewParams,
 };
 use crate::render_types::{CpuContext, CpuRenderPass, GpuContext, PrepareResult, RenderResult};
 use crate::viewport::{DataCoord, ScreenCoord};
@@ -706,6 +706,8 @@ impl DrawToSvg for StrokedPolygonLayer {
 }
 
 impl BrushableLayer for StrokedPolygonLayer {}
+
+impl ExtentableLayer for StrokedPolygonLayer {}
 
 impl PickableLayer for StrokedPolygonLayer {
     fn pick(&self, _screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/layers/text_layer.rs
+++ b/crates/pluot_core/src/layers/text_layer.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use fontdue::layout::{CoordinateSystem, Layout, LayoutSettings, TextStyle};
 use fontdue::{Font, FontSettings};
 
-use crate::render_traits::{AspectRatioMode, AspectRatioAlignmentMode, BrushableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, EmphasisCriteria, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams, FontWeight, FontStyle};
+use crate::render_traits::{AspectRatioMode, AspectRatioAlignmentMode, BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, EmphasisCriteria, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams, FontWeight, FontStyle};
 use crate::numeric_data::NumericData;
 use crate::picking::LayerPickingResult;
 use crate::render_types::{CpuContext, CpuRenderPass, PrepareResult, RenderResult};
@@ -1356,6 +1356,8 @@ inventory::submit! {
 }
 
 impl BrushableLayer for TextLayer {}
+
+impl ExtentableLayer for TextLayer {}
 
 impl PickableLayer for TextLayer {
     fn pick(&self, _screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_core/src/layers/triangulated_layer.rs
+++ b/crates/pluot_core/src/layers/triangulated_layer.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use crate::positioning::get_point_position;
 use crate::render_traits::{
     AspectRatioAlignmentMode, AspectRatioMode, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg,
-    BrushableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, UnitsMode, ViewParams,
+    BrushableLayer, ExtentableLayer, EmphasisCriteria, MarginParams, OpacityMode, PickableLayer, PreparedLayer, UnitsMode, ViewParams,
 };
 use crate::render_types::{CpuContext, CpuRenderPass, GpuContext, PrepareResult, RenderResult};
 use crate::numeric_data::NumericData;
@@ -594,5 +594,7 @@ impl DrawToSvg for TriangulatedLayer {
 }
 
 impl BrushableLayer for TriangulatedLayer {}
+
+impl ExtentableLayer for TriangulatedLayer {}
 
 impl PickableLayer for TriangulatedLayer {}

--- a/crates/pluot_core/src/lib.rs
+++ b/crates/pluot_core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod numeric_data;
 pub mod viewport;
 mod picking;
 mod brushing;
+mod extent;
 pub mod layers;
 pub(crate) mod curve_and_polygon_utils;
 pub(crate) mod picking_geometry;
@@ -54,6 +55,7 @@ pub use crate::zarr::{AsyncZarritaStore, StoreMap};
 pub use crate::render_script::{render_to_script, render_to_script_aux};
 pub use crate::picking::{pick, PickingResult, LayerPickingResult};
 pub use crate::brushing::{brush, BrushParams, BrushingResult, LayerBrushingResult};
+pub use crate::extent::{extent, ExtentResult, LayerExtentResult};
 pub use crate::viewport::{project, unproject, get_bounds, camera_matrix_to_zoom_and_translation};
 pub use crate::numeric_data::NumericData;
 

--- a/crates/pluot_core/src/render_traits.rs
+++ b/crates/pluot_core/src/render_traits.rs
@@ -1,5 +1,6 @@
 use crate::picking::LayerPickingResult;
 use crate::brushing::{LayerBrushingResult, BrushParams};
+use crate::extent::LayerExtentResult;
 use crate::numeric_data::NumericData;
 use crate::viewport::{DataCoord, DataVertices, ScreenCoord};
 use crate::wgpu;
@@ -647,6 +648,17 @@ pub trait BrushableLayer {
     }
 }
 
+/// Report the layer's data extent: the min/max bounds along the x and y axes (and z, if 3D).
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait ExtentableLayer {
+    // TODO: should this be async?
+    fn extent(&self) -> Option<LayerExtentResult> {
+        // Default implementation: extent unknown, return None.
+        None
+    }
+}
+
 
 // Stub trait for CPU-based compute operations.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -674,8 +686,8 @@ pub trait PreparedAndDrawToRasterCpu: PreparedLayer + DrawToRasterCpu + MaybeSen
 impl<T: PreparedLayer + DrawToRasterCpu + MaybeSend + MaybeSync> PreparedAndDrawToRasterCpu for T {}
 
 // Trait for layers that can prepare and render to all output formats.
-pub trait PreparedAndDraw: PreparedLayer + DrawToSvg + DrawToRasterGpu + DrawToRasterCpu + PickableLayer + BrushableLayer + MaybeSend + MaybeSync {}
-impl<T: PreparedLayer + DrawToSvg + DrawToRasterGpu + DrawToRasterCpu + PickableLayer + BrushableLayer + MaybeSend + MaybeSync> PreparedAndDraw for T {}
+pub trait PreparedAndDraw: PreparedLayer + DrawToSvg + DrawToRasterGpu + DrawToRasterCpu + PickableLayer + BrushableLayer + ExtentableLayer + MaybeSend + MaybeSync {}
+impl<T: PreparedLayer + DrawToSvg + DrawToRasterGpu + DrawToRasterCpu + PickableLayer + BrushableLayer + ExtentableLayer + MaybeSend + MaybeSync> PreparedAndDraw for T {}
 
 
 

--- a/crates/pluot_zarr/src/layers/adata_zarr_dotplot_layer.rs
+++ b/crates/pluot_zarr/src/layers/adata_zarr_dotplot_layer.rs
@@ -8,7 +8,7 @@ use pluot_core::wgpu;
 use pluot_core::zarr::is_timed_out_zarrs_error;
 use zarrs::storage::AsyncReadableStorageTraits;
 use pluot_core::two::svg::SvgContext;
-use pluot_core::render_traits::{BrushableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, InstancedSizeParams, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, QuantitativeColormap, QuantitativeParams, SizeMode, UnitsMode, ViewParams, resolve_store_name};
+use pluot_core::render_traits::{BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, InstancedSizeParams, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, QuantitativeColormap, QuantitativeParams, SizeMode, UnitsMode, ViewParams, resolve_store_name};
 use pluot_core::render_types::{CpuContext, CpuRenderPass, PrepareResult};
 use pluot_core::render_types::GpuContext;
 use pluot_core::composite_layer::{base_draw_composite_layer, base_draw_composite_layer_svg};
@@ -451,6 +451,8 @@ impl DrawToSvg for AdataZarrDotPlotLayer {
 }
 
 impl BrushableLayer for AdataZarrDotPlotLayer {}
+
+impl ExtentableLayer for AdataZarrDotPlotLayer {}
 
 impl PickableLayer for AdataZarrDotPlotLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_zarr/src/layers/ome_zarr_bitmap_layer.rs
+++ b/crates/pluot_zarr/src/layers/ome_zarr_bitmap_layer.rs
@@ -10,7 +10,7 @@ use pluot_core::cache::use_memo_numeric_data;
 use pluot_core::zarr::is_timed_out_zarrs_error;
 use zarrs::storage::AsyncReadableStorageTraits;
 use pluot_core::render_traits::{
-    BrushableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams, resolve_store_name,
+    BrushableLayer, ExtentableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams, resolve_store_name,
 };
 use pluot_core::two::svg::SvgContext;
 use pluot_core::layers::bitmap_layer::{
@@ -428,6 +428,8 @@ impl DrawToSvg for OmeZarrBitmapLayer {
 }
 
 impl BrushableLayer for OmeZarrBitmapLayer {}
+
+impl ExtentableLayer for OmeZarrBitmapLayer {}
 
 impl PickableLayer for OmeZarrBitmapLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_zarr/src/layers/ome_zarr_bitmap_multiscale_layer.rs
+++ b/crates/pluot_zarr/src/layers/ome_zarr_bitmap_multiscale_layer.rs
@@ -10,7 +10,7 @@ use pluot_core::log;
 use pluot_core::wgpu;
 use zarrs::storage::AsyncReadableStorageTraits;
 use pluot_core::render_traits::{
-    BrushableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, ViewParams, resolve_store_name,
+    BrushableLayer, ExtentableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, ViewParams, resolve_store_name,
 };
 use pluot_core::two::svg::SvgContext;
 use pluot_core::multiscale_utils::{
@@ -587,6 +587,8 @@ impl DrawToSvg for OmeZarrBitmapMultiscaleLayer {
 }
 
 impl BrushableLayer for OmeZarrBitmapMultiscaleLayer {}
+
+impl ExtentableLayer for OmeZarrBitmapMultiscaleLayer {}
 
 impl PickableLayer for OmeZarrBitmapMultiscaleLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_zarr/src/layers/ome_zarr_bitmask_layer.rs
+++ b/crates/pluot_zarr/src/layers/ome_zarr_bitmask_layer.rs
@@ -10,7 +10,7 @@ use pluot_core::cache::use_memo_numeric_data;
 use pluot_core::zarr::is_timed_out_zarrs_error;
 use zarrs::storage::AsyncReadableStorageTraits;
 use pluot_core::render_traits::{
-    BrushableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams, resolve_store_name,
+    BrushableLayer, ExtentableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams, resolve_store_name,
 };
 use pluot_core::two::svg::SvgContext;
 use pluot_core::layers::bitmask_layer::{
@@ -446,6 +446,8 @@ impl DrawToSvg for OmeZarrBitmaskLayer {
 }
 
 impl BrushableLayer for OmeZarrBitmaskLayer {}
+
+impl ExtentableLayer for OmeZarrBitmaskLayer {}
 
 impl PickableLayer for OmeZarrBitmaskLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_zarr/src/layers/ome_zarr_bitmask_multiscale_layer.rs
+++ b/crates/pluot_zarr/src/layers/ome_zarr_bitmask_multiscale_layer.rs
@@ -10,7 +10,7 @@ use pluot_core::log;
 use pluot_core::wgpu;
 use zarrs::storage::AsyncReadableStorageTraits;
 use pluot_core::render_traits::{
-    BrushableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams, resolve_store_name,
+    BrushableLayer, ExtentableLayer, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, MarginParams, PickableLayer, PreparedLayer, UnitsMode, ViewParams, resolve_store_name,
 };
 use pluot_core::two::svg::SvgContext;
 use pluot_core::multiscale_utils::{
@@ -584,6 +584,8 @@ impl DrawToSvg for OmeZarrBitmaskMultiscaleLayer {
 }
 
 impl BrushableLayer for OmeZarrBitmaskMultiscaleLayer {}
+
+impl ExtentableLayer for OmeZarrBitmaskMultiscaleLayer {}
 
 impl PickableLayer for OmeZarrBitmaskMultiscaleLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_zarr/src/layers/zarr_bar_plot_layer.rs
+++ b/crates/pluot_zarr/src/layers/zarr_bar_plot_layer.rs
@@ -8,7 +8,7 @@ use pluot_core::cache::{use_memo_vec_f32, use_memo_vec_string};
 use pluot_core::zarr::is_timed_out_zarrs_error;
 use zarrs::storage::AsyncReadableStorageTraits;
 use pluot_core::two::svg::{update_svg, SvgContext};
-use pluot_core::render_traits::{BrushableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, UnitsMode, ViewParams, resolve_store_name};
+use pluot_core::render_traits::{BrushableLayer, ExtentableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, UnitsMode, ViewParams, resolve_store_name};
 use pluot_core::render_types::{CpuContext, CpuRenderPass, PrepareResult};
 use pluot_core::render_types::GpuContext;
 use pluot_core::d3::scale::{ScaleBand, Scaleable};
@@ -173,6 +173,8 @@ impl DrawToSvg for ZarrBarPlotLayer {
 }
 
 impl BrushableLayer for ZarrBarPlotLayer {}
+
+impl ExtentableLayer for ZarrBarPlotLayer {}
 
 impl PickableLayer for ZarrBarPlotLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_zarr/src/layers/zarr_histogram_layer.rs
+++ b/crates/pluot_zarr/src/layers/zarr_histogram_layer.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
-use pluot_core::{maybe_timeout, FutureExt, Duration, log, BrushParams, LayerBrushingResult};
+use pluot_core::{maybe_timeout, FutureExt, Duration, log, BrushParams, LayerBrushingResult, LayerExtentResult};
 
 use pluot_core::wgpu;
 use pluot_core::cache::use_memo_vec_f32;
@@ -10,7 +10,7 @@ use pluot_core::params::BrushMode;
 use pluot_core::zarr::is_timed_out_zarrs_error;
 use zarrs::storage::AsyncReadableStorageTraits;
 use pluot_core::two::svg::SvgContext;
-use pluot_core::render_traits::{BrushableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, UnitsMode, ViewParams, resolve_store_name};
+use pluot_core::render_traits::{BrushableLayer, ColorMode, DrawToRasterCpu, DrawToRasterGpu, DrawToSvg, ExtentableLayer, MarginParams, PickableLayer, PreparedAndDraw, PreparedLayer, UnitsMode, ViewParams, resolve_store_name};
 use pluot_core::render_types::{CpuContext, CpuRenderPass, PrepareResult};
 use pluot_core::render_types::GpuContext;
 use pluot_core::composite_layer::{base_draw_composite_layer, base_draw_composite_layer_svg};
@@ -86,6 +86,11 @@ pub struct ZarrHistogramLayer {
     // around so that a brush selection along this axis can be resolved back
     // to a data value range.
     value_scale: Option<ScaleLinear>,
+
+    // The largest "background" (filter-included) bin count, i.e. the upper
+    // bound of the count axis. Kept around so `extent` can report it without
+    // re-deriving the histogram.
+    max_count: Option<f32>,
 }
 
 impl ZarrHistogramLayer {
@@ -100,6 +105,7 @@ impl ZarrHistogramLayer {
             store_name,
             sub_layer_instances: Vec::new(),
             value_scale: None,
+            max_count: None,
         }
     }
 
@@ -279,6 +285,7 @@ impl PreparedLayer for ZarrHistogramLayer {
 
         let value_scale = Self::build_value_scale(&self.view_params, &self.layer_params.orientation, (data_min as f64, data_max as f64));
         self.value_scale = Some(value_scale);
+        self.max_count = Some(background_arr.iter().cloned().fold(0.0f32, f32::max));
 
         // The foreground ("selected") bin counts get their own memo.
         let foreground_future = use_memo_vec_f32(async || {
@@ -465,3 +472,29 @@ impl BrushableLayer for ZarrHistogramLayer {
 }
 
 impl PickableLayer for ZarrHistogramLayer {}
+
+impl ExtentableLayer for ZarrHistogramLayer {
+    fn extent(&self) -> Option<LayerExtentResult> {
+        let (data_min, data_max) = self.value_scale.as_ref()?.get_domain();
+        let (data_min, data_max) = (data_min as f32, data_max as f32);
+        let max_count = self.max_count?;
+
+        // The value axis (binned value domain) runs along X for a vertical
+        // histogram, and along Y for a horizontal one; the count axis (bin
+        // heights, which always start at zero) takes the other axis.
+        let (x_min, x_max, y_min, y_max) = match self.layer_params.orientation {
+            BarOrientation::Vertical => (data_min, data_max, 0.0, max_count),
+            BarOrientation::Horizontal => (0.0, max_count, data_min, data_max),
+        };
+
+        Some(LayerExtentResult {
+            layer_id: self.layer_params.layer_id.clone(),
+            x_min,
+            x_max,
+            y_min,
+            y_max,
+            z_min: None,
+            z_max: None,
+        })
+    }
+}

--- a/crates/pluot_zarr/src/layers/zarr_histogram_layer.rs
+++ b/crates/pluot_zarr/src/layers/zarr_histogram_layer.rs
@@ -482,19 +482,16 @@ impl ExtentableLayer for ZarrHistogramLayer {
         // The value axis (binned value domain) runs along X for a vertical
         // histogram, and along Y for a horizontal one; the count axis (bin
         // heights, which always start at zero) takes the other axis.
-        let (x_min, x_max, y_min, y_max) = match self.layer_params.orientation {
-            BarOrientation::Vertical => (data_min, data_max, 0.0, max_count),
-            BarOrientation::Horizontal => (0.0, max_count, data_min, data_max),
+        let (x, y) = match self.layer_params.orientation {
+            BarOrientation::Vertical => ((data_min, data_max), (0.0, max_count)),
+            BarOrientation::Horizontal => ((0.0, max_count), (data_min, data_max)),
         };
 
         Some(LayerExtentResult {
             layer_id: self.layer_params.layer_id.clone(),
-            x_min,
-            x_max,
-            y_min,
-            y_max,
-            z_min: None,
-            z_max: None,
+            x,
+            y,
+            z: None,
         })
     }
 }

--- a/crates/pluot_zarr/src/layers/zarr_point_3d_layer.rs
+++ b/crates/pluot_zarr/src/layers/zarr_point_3d_layer.rs
@@ -11,7 +11,7 @@ use pluot_core::cache::{use_memo_vec_f32, use_memo_vec_i32};
 use pluot_core::zarr::is_timed_out_zarrs_error;
 use zarrs::storage::AsyncReadableStorageTraits;
 use pluot_core::two::svg::SvgContext;
-use pluot_core::render_traits::{BrushableLayer, CategoricalColormap, CategoricalParams, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, PickableLayer, PreparedLayer, ViewParams, MarginParams, resolve_store_name};
+use pluot_core::render_traits::{BrushableLayer, ExtentableLayer, CategoricalColormap, CategoricalParams, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, PickableLayer, PreparedLayer, ViewParams, MarginParams, resolve_store_name};
 use pluot_core::layers::point_layer::PointShapeMode;
 use pluot_core::layers::point_3d_layer::{Point3dLayer, Point3dLayerParams};
 use pluot_core::render_types::{CpuContext, CpuRenderPass, PrepareResult};
@@ -211,6 +211,8 @@ impl DrawToSvg for ZarrPoint3dLayer {
 }
 
 impl BrushableLayer for ZarrPoint3dLayer {}
+
+impl ExtentableLayer for ZarrPoint3dLayer {}
 
 impl PickableLayer for ZarrPoint3dLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {

--- a/crates/pluot_zarr/src/layers/zarr_point_layer.rs
+++ b/crates/pluot_zarr/src/layers/zarr_point_layer.rs
@@ -9,7 +9,7 @@ use zarrs::storage::AsyncReadableStorageTraits;
 use pluot_core::compute::reduce::reduce_extent;
 use pluot_core::zarr::is_timed_out_zarrs_error;
 use pluot_core::two::svg::{update_svg, SvgContext};
-use pluot_core::render_traits::{BrushableLayer, CategoricalColormap, CategoricalParams, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, OpacityMode, PickableLayer, PreparedLayer, SizeMode, ViewParams, AspectRatioMode, UnitsMode, MarginParams, resolve_store_name};
+use pluot_core::render_traits::{BrushableLayer, ExtentableLayer, CategoricalColormap, CategoricalParams, ColorMode, DrawToRasterGpu, DrawToRasterCpu, DrawToSvg, OpacityMode, PickableLayer, PreparedLayer, SizeMode, ViewParams, AspectRatioMode, UnitsMode, MarginParams, resolve_store_name};
 use pluot_core::layers::point_layer::{PointLayer, PointShapeMode, PointLayerParams};
 use pluot_core::numeric_data::NumericData;
 use pluot_core::render_types::{CpuContext, CpuRenderPass, PrepareResult, RenderResult};
@@ -466,6 +466,8 @@ impl DrawToSvg for ZarrPointLayer {
 }
 
 impl BrushableLayer for ZarrPointLayer {}
+
+impl ExtentableLayer for ZarrPointLayer {}
 
 impl PickableLayer for ZarrPointLayer {
     fn pick(&self, screen_coord: ScreenCoord, data_coord: Option<DataCoord>) -> Option<LayerPickingResult> {


### PR DESCRIPTION
Towards #34 

TODO:
- [ ] finish the todos in the react component
- [ ] cache the `extent_wasm` result and use it for brushing in data-space; remove the `brush_wasm` call during brushing